### PR TITLE
Enhance DiceRoller functionality with flexible API and example usage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/arbrynnica/utils/dice_roller.py
+++ b/src/arbrynnica/utils/dice_roller.py
@@ -1,39 +1,62 @@
 # src/arbrynnica/utils/dice_roller.py
 
 import random
-from typing import List
+from typing import Optional, Union
+
+class DiceRollConfig:
+    """Configuration class for dice rolling."""
+    def __init__(self, num_dice: int, num_sides: int, drop_lowest: bool = False) -> None:
+        self.num_dice = num_dice
+        self.num_sides = num_sides
+        self.drop_lowest = drop_lowest
 
 class DiceRoller:
     """Utility class for rolling dice."""
 
     @staticmethod
-    def roll_dice(num_dice: int, num_sides: int) -> List[int]:
+    def roll(num_dice: Union[int, str], num_sides: Optional[int] = None, drop_lowest: bool = False) -> int:
         """Rolls a specified number of dice with a given number of sides.
 
         Args:
-            num_dice (int): Number of dice to roll.
-            num_sides (int): Number of sides on each die.
+            num_dice (Union[int, str]): Number of dice to roll or dice notation (e.g., '3d6').
+            num_sides (Optional[int]): Number of sides on each die. Required if num_dice is an int.
+            drop_lowest (bool): Whether to drop the lowest roll. Defaults to False.
 
         Returns:
-            List[int]: Results of the dice rolls.
+            int: Sum of the dice rolls based on the provided configuration.
+
+        Raises:
+            ValueError: If num_dice or num_sides is less than 1, or if the notation is not supported.
         """
-        return [random.randint(1, num_sides) for _ in range(num_dice)]
+        if isinstance(num_dice, str):
+            config = DiceRoller.parse_dice_notation(num_dice, drop_lowest)
+            return DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
+
+        if num_dice < 1 or num_sides is None or num_sides < 1:
+            raise ValueError("Number of dice and sides must be at least 1.")
+
+        rolls = [random.randint(1, num_sides) for _ in range(num_dice)]
+        if drop_lowest:
+            return sum(sorted(rolls)[1:])
+        return sum(rolls)
 
     @staticmethod
-    def roll_3d6() -> int:
-        """Rolls 3 six-sided dice and returns the sum.
+    def parse_dice_notation(dice_notation: str, drop_lowest: bool = False) -> DiceRollConfig:
+        """Parses a dice notation string and returns a configuration object.
+
+        Args:
+            dice_notation (str): String describing the dice roll format.
+            drop_lowest (bool): Whether to drop the lowest roll. Defaults to False.
 
         Returns:
-            int: Sum of the dice rolls.
-        """
-        return sum(DiceRoller.roll_dice(3, 6))
+            DiceRollConfig: Configuration object based on the provided notation.
 
-    @staticmethod
-    def roll_4d6_drop_lowest() -> int:
-        """Rolls 4 six-sided dice, drops the lowest roll, and returns the sum of the remaining three.
-
-        Returns:
-            int: Sum of the three highest dice rolls.
+        Raises:
+            ValueError: If the notation is not in the supported format.
         """
-        rolls = DiceRoller.roll_dice(4, 6)
-        return sum(sorted(rolls)[1:])
+        try:
+            num_dice, num_sides = map(int, dice_notation.split('d'))
+        except ValueError:
+            raise ValueError("Unsupported dice notation format.")
+
+        return DiceRollConfig(num_dice=num_dice, num_sides=num_sides, drop_lowest=drop_lowest)

--- a/src/arbrynnica/utils/dice_roller.py
+++ b/src/arbrynnica/utils/dice_roller.py
@@ -3,7 +3,7 @@
 import random
 from typing import Optional, Union
 
-class DiceRollConfig:
+class _DiceRollConfig:
     """Configuration class for dice rolling."""
     def __init__(self, num_dice: int, num_sides: int, drop_lowest: bool = False) -> None:
         self.num_dice = num_dice
@@ -27,9 +27,19 @@ class DiceRoller:
 
         Raises:
             ValueError: If num_dice or num_sides is less than 1, or if the notation is not supported.
+
+        Examples:
+            >>> DiceRoller.roll(3, 6)
+            10  # Example output, actual result will vary
+
+            >>> DiceRoller.roll('3d6')
+            12  # Example output, actual result will vary
+
+            >>> DiceRoller.roll('4d6', drop_lowest=True)
+            14  # Example output, actual result will vary
         """
         if isinstance(num_dice, str):
-            config = DiceRoller.parse_dice_notation(num_dice, drop_lowest)
+            config = DiceRoller._parse_dice_notation(num_dice, drop_lowest)
             return DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
 
         if num_dice < 1 or num_sides is None or num_sides < 1:
@@ -41,7 +51,7 @@ class DiceRoller:
         return sum(rolls)
 
     @staticmethod
-    def parse_dice_notation(dice_notation: str, drop_lowest: bool = False) -> DiceRollConfig:
+    def _parse_dice_notation(dice_notation: str, drop_lowest: bool = False) -> _DiceRollConfig:
         """Parses a dice notation string and returns a configuration object.
 
         Args:
@@ -49,7 +59,7 @@ class DiceRoller:
             drop_lowest (bool): Whether to drop the lowest roll. Defaults to False.
 
         Returns:
-            DiceRollConfig: Configuration object based on the provided notation.
+            _DiceRollConfig: Configuration object based on the provided notation.
 
         Raises:
             ValueError: If the notation is not in the supported format.
@@ -59,4 +69,4 @@ class DiceRoller:
         except ValueError:
             raise ValueError("Unsupported dice notation format.")
 
-        return DiceRollConfig(num_dice=num_dice, num_sides=num_sides, drop_lowest=drop_lowest)
+        return _DiceRollConfig(num_dice=num_dice, num_sides=num_sides, drop_lowest=drop_lowest)

--- a/tests/test_dice_roller.py
+++ b/tests/test_dice_roller.py
@@ -21,24 +21,14 @@ def test_roll_with_notation():
     result_drop_lowest = DiceRoller.roll('4d6', drop_lowest=True)
     assert 3 <= result_drop_lowest <= 18
 
-def test_roll_3d6():
-    """Test rolling 3 six-sided dice and returning the sum."""
-    result = DiceRoller.roll('3d6')
-    assert 3 <= result <= 18
-
-def test_roll_4d6_drop_lowest():
-    """Test rolling 4 six-sided dice, dropping the lowest roll, and returning the sum of the remaining three."""
-    result = DiceRoller.roll('4d6', drop_lowest=True)
-    assert 3 <= result <= 18
-
 def test_parse_dice_notation():
     """Test parsing dice notation strings and rolling dice accordingly."""
-    config_3d6 = DiceRoller.parse_dice_notation('3d6')
+    config_3d6 = DiceRoller._parse_dice_notation('3d6')
     assert config_3d6.num_dice == 3
     assert config_3d6.num_sides == 6
     assert not config_3d6.drop_lowest
 
-    config_4d6_drop_lowest = DiceRoller.parse_dice_notation('4d6', drop_lowest=True)
+    config_4d6_drop_lowest = DiceRoller._parse_dice_notation('4d6', drop_lowest=True)
     assert config_4d6_drop_lowest.num_dice == 4
     assert config_4d6_drop_lowest.num_sides == 6
     assert config_4d6_drop_lowest.drop_lowest
@@ -57,10 +47,10 @@ def test_roll_invalid_input():
 def test_parse_dice_notation_invalid_input():
     """Test parsing invalid dice notation strings."""
     with pytest.raises(ValueError):
-        DiceRoller.parse_dice_notation('2d')
+        DiceRoller._parse_dice_notation('2d')
     with pytest.raises(ValueError):
-        DiceRoller.parse_dice_notation('d6')
+        DiceRoller._parse_dice_notation('d6')
     with pytest.raises(ValueError):
-        DiceRoller.parse_dice_notation('3d6 drop')
+        DiceRoller._parse_dice_notation('3d6 drop')
     with pytest.raises(ValueError):
-        DiceRoller.parse_dice_notation('3d6 keep highest')
+        DiceRoller._parse_dice_notation('3d6 keep highest')

--- a/tests/test_dice_roller.py
+++ b/tests/test_dice_roller.py
@@ -3,19 +3,64 @@
 import pytest
 from arbrynnica.utils.dice_roller import DiceRoller
 
-def test_roll_dice():
+def test_roll():
     """Test rolling a specified number of dice with a given number of sides."""
-    rolls = DiceRoller.roll_dice(3, 6)
-    assert len(rolls) == 3
-    for roll in rolls:
-        assert 1 <= roll <= 6
+    result = DiceRoller.roll(3, 6)
+    assert 3 <= result <= 18
+
+def test_roll_with_drop_lowest():
+    """Test rolling a specified number of dice with dropping the lowest roll."""
+    result = DiceRoller.roll(4, 6, drop_lowest=True)
+    assert 3 <= result <= 18
+
+def test_roll_with_notation():
+    """Test rolling dice using notation."""
+    result = DiceRoller.roll('3d6')
+    assert 3 <= result <= 18
+
+    result_drop_lowest = DiceRoller.roll('4d6', drop_lowest=True)
+    assert 3 <= result_drop_lowest <= 18
 
 def test_roll_3d6():
     """Test rolling 3 six-sided dice and returning the sum."""
-    total = DiceRoller.roll_3d6()
-    assert 3 <= total <= 18
+    result = DiceRoller.roll('3d6')
+    assert 3 <= result <= 18
 
 def test_roll_4d6_drop_lowest():
     """Test rolling 4 six-sided dice, dropping the lowest roll, and returning the sum of the remaining three."""
-    total = DiceRoller.roll_4d6_drop_lowest()
-    assert 3 <= total <= 18
+    result = DiceRoller.roll('4d6', drop_lowest=True)
+    assert 3 <= result <= 18
+
+def test_parse_dice_notation():
+    """Test parsing dice notation strings and rolling dice accordingly."""
+    config_3d6 = DiceRoller.parse_dice_notation('3d6')
+    assert config_3d6.num_dice == 3
+    assert config_3d6.num_sides == 6
+    assert not config_3d6.drop_lowest
+
+    config_4d6_drop_lowest = DiceRoller.parse_dice_notation('4d6', drop_lowest=True)
+    assert config_4d6_drop_lowest.num_dice == 4
+    assert config_4d6_drop_lowest.num_sides == 6
+    assert config_4d6_drop_lowest.drop_lowest
+
+def test_roll_invalid_input():
+    """Test rolling dice with invalid inputs."""
+    with pytest.raises(ValueError):
+        DiceRoller.roll(0, 6)
+    with pytest.raises(ValueError):
+        DiceRoller.roll(3, 0)
+    with pytest.raises(ValueError):
+        DiceRoller.roll(-1, 6)
+    with pytest.raises(ValueError):
+        DiceRoller.roll(3, -1)
+
+def test_parse_dice_notation_invalid_input():
+    """Test parsing invalid dice notation strings."""
+    with pytest.raises(ValueError):
+        DiceRoller.parse_dice_notation('2d')
+    with pytest.raises(ValueError):
+        DiceRoller.parse_dice_notation('d6')
+    with pytest.raises(ValueError):
+        DiceRoller.parse_dice_notation('3d6 drop')
+    with pytest.raises(ValueError):
+        DiceRoller.parse_dice_notation('3d6 keep highest')


### PR DESCRIPTION
- PR author: art
- PR reviewers: brynn, celica

This PR enhances the `DiceRoller` class by providing a flexible API that supports both integer-based and string-based inputs for rolling dice. The goal is to simplify the interface while ensuring robust functionality and ease of use for library consumers.

**Changes:**
1. **Enhanced `roll` Method:**
    - The `roll` method now accepts both integer-based and string-based inputs for specifying the number of dice and sides.
    - Added optional `drop_lowest` argument to handle dropping the lowest roll.

2. **Private Configuration Class:**
    - Introduced a private `_DiceRollConfig` class to encapsulate dice roll configurations internally.

3. **Private Notation Parsing:**
    - Made the `_parse_dice_notation` method private to encapsulate internal logic and reduce public API surface.

4. **Example Usage in Docstrings:**
    - Added example code snippets in the `roll` method's docstring to provide immediate guidance on usage.

5. **Removed Redundant Methods:**
    - Removed the redundant `roll_3d6` and `roll_4d6_drop_lowest` methods and tested these scenarios using the `roll` method directly.

6. **Updated Tests:**
    - Updated and added tests to cover various scenarios, including integer-based input, string-based input, dropping the lowest roll, and invalid inputs.

**Testing:**
- All tests have been updated and verified to ensure the functionality works as expected.
- Verified that the implementation handles various dice rolling scenarios and edge cases effectively.

**Documentation:**
- Enhanced docstrings with clear explanations and examples to improve usability and understandability.

**Example Usage:**

```python
# Roll 3 six-sided dice
result = DiceRoller.roll(3, 6)

# Roll 3 six-sided dice using notation
result = DiceRoller.roll('3d6')

# Roll 4 six-sided dice and drop the lowest roll
result = DiceRoller.roll('4d6', drop_lowest=True)
```