### PR TITLE
dice work + ruff format

### DIFF
--- a/src/arbrynnica/character.py
+++ b/src/arbrynnica/character.py
@@ -19,6 +19,7 @@ from arbrynnica.spell import Spell
 from arbrynnica.modifier import Modifier
 from arbrynnica.condition import Condition
 
+
 class CharacterClass:
     """Represents a character class in the RPG.
 
@@ -46,7 +47,16 @@ class CharacterClass:
         )
         ```
     """
-    def __init__(self, name: str, hit_die: int, prime_requisites: List[str], spells: List[Spell], equipment: List[Item], skills: List[str]) -> None:
+
+    def __init__(
+        self,
+        name: str,
+        hit_die: int,
+        prime_requisites: List[str],
+        spells: List[Spell],
+        equipment: List[Item],
+        skills: List[str],
+    ) -> None:
         """Initializes a character class.
 
         Args:
@@ -69,7 +79,7 @@ class CharacterClass:
         self.equipment = equipment
         self.skills = skills
 
-    def level_up(self, character: 'Character') -> None:
+    def level_up(self, character: "Character") -> None:
         """Levels up the character.
 
         Call this method when the character has gained enough experience points to reach a new level. This will increase their hit points and potentially grant new abilities or spells.
@@ -87,7 +97,7 @@ class CharacterClass:
         """
         pass  # Implementation for leveling up
 
-    def apply_class_specific_bonuses(self, character: 'Character') -> None:
+    def apply_class_specific_bonuses(self, character: "Character") -> None:
         """Applies class-specific bonuses to the character.
 
         Call this method to apply bonuses specific to the character's class, such as bonus spells or special abilities. This should be done after leveling up or when class-specific conditions are met.
@@ -105,6 +115,7 @@ class CharacterClass:
             ```
         """
         pass  # Implementation for class-specific bonuses
+
 
 class Abilities:
     """Represents a character's abilities, such as strength and intelligence.
@@ -124,7 +135,10 @@ class Abilities:
         abilities = Abilities(15, 10, 10, 12, 14, 8)
         ```
     """
-    def __init__(self, strength: int, intelligence: int, wisdom: int, dexterity: int, constitution: int, charisma: int) -> None:
+
+    def __init__(
+        self, strength: int, intelligence: int, wisdom: int, dexterity: int, constitution: int, charisma: int
+    ) -> None:
         """Initializes a character's abilities with the given scores.
 
         Ability scores typically range from 3 to 18, as determined by rolling 3d6 for each ability, according to the game mechanics.
@@ -181,6 +195,7 @@ class Abilities:
         """
         pass
 
+
 class Alignment:
     """Represents a character's alignment.
 
@@ -194,6 +209,7 @@ class Alignment:
         alignment = Alignment("Lawful")
         ```
     """
+
     def __init__(self, type: str) -> None:
         """Initializes a character's alignment.
 
@@ -201,6 +217,7 @@ class Alignment:
             type (str): The alignment of the character. Options: 'Lawful', 'Neutral', 'Chaotic'.
         """
         self.type = type
+
 
 class Character:
     """Represents a character in the RPG.
@@ -229,6 +246,7 @@ class Character:
         character = Character("Arthas", char_class, abilities, alignment)
         ```
     """
+
     def __init__(self, name: str, char_class: CharacterClass, abilities: Abilities, alignment: Alignment) -> None:
         """Initializes a player character with the given name, class, abilities, and alignment.
 
@@ -271,9 +289,9 @@ class Character:
             character.hit_points = character.calculate_hit_points()
             ```
         """
-        base_hp = self.char_class.hit_die + self.get_ability_modifier('constitution')
-        active_modifiers = [mod for mod in self.modifiers if mod.is_active(self) and mod.scope == 'global']
-        return base_hp + sum(mod.value for mod in active_modifiers if mod.name == 'hit_points')
+        base_hp = self.char_class.hit_die + self.get_ability_modifier("constitution")
+        active_modifiers = [mod for mod in self.modifiers if mod.is_active(self) and mod.scope == "global"]
+        return base_hp + sum(mod.value for mod in active_modifiers if mod.name == "hit_points")
 
     def roll_initiative(self) -> int:
         """Rolls for initiative based on the character's dexterity and active modifiers.
@@ -305,9 +323,11 @@ class Character:
             ```
         """
         base_modifier = (getattr(self.abilities, ability) - 10) // 2
-        active_modifiers = [mod for mod in self.modifiers if mod.is_active(self) and mod.scope in ('global', 'combat')]
-        flat_modifiers = sum(mod.value for mod in active_modifiers if mod.name == ability and mod.type == 'flat')
-        percentage_modifiers = sum(mod.value for mod in active_modifiers if mod.name == ability and mod.type == 'percentage')
+        active_modifiers = [mod for mod in self.modifiers if mod.is_active(self) and mod.scope in ("global", "combat")]
+        flat_modifiers = sum(mod.value for mod in active_modifiers if mod.name == ability and mod.type == "flat")
+        percentage_modifiers = sum(
+            mod.value for mod in active_modifiers if mod.name == ability and mod.type == "percentage"
+        )
         return self.apply_percentage_modifier(base_modifier + flat_modifiers, percentage_modifiers)
 
     @staticmethod
@@ -447,7 +467,7 @@ class Character:
         """
         self.char_class.spells.append(spell)
 
-    def cast_spell(self, spell: Spell, target: 'Character') -> None:
+    def cast_spell(self, spell: Spell, target: "Character") -> None:
         """Casts a spell on a target character.
 
         Call this method to cast a spell, targeting another character.

--- a/src/arbrynnica/condition.py
+++ b/src/arbrynnica/condition.py
@@ -11,6 +11,7 @@ Typical usage example:
     ```
 """
 
+
 class Condition:
     """Represents a condition in the RPG.
 
@@ -35,6 +36,7 @@ class Condition:
         poisoned_condition.apply(character)
         ```
     """
+
     def __init__(self, name: str, description: str, duration: int) -> None:
         """Initializes a condition.
 
@@ -52,7 +54,7 @@ class Condition:
         self.description = description
         self.duration = duration
 
-    def apply(self, character: 'Character') -> None:
+    def apply(self, character: "Character") -> None:
         """Applies the condition to the character.
 
         Call this method to apply the condition to the character, altering their status or abilities.
@@ -70,7 +72,7 @@ class Condition:
         if self.name == "Poisoned":
             character.hit_points -= 1  # Example effect: Reduce health by 1
 
-    def remove(self, character: 'Character') -> None:
+    def remove(self, character: "Character") -> None:
         """Removes the condition from the character.
 
         Call this method to remove the condition's effects from the character. This method should be used to revert any changes made by the condition.

--- a/src/arbrynnica/inventory.py
+++ b/src/arbrynnica/inventory.py
@@ -14,6 +14,7 @@ Typical usage example:
 
 from typing import List, Dict
 
+
 class Item:
     """Represents an item in the RPG.
 
@@ -28,6 +29,7 @@ class Item:
         sword = Item("Sword", "weapon", 10)
         ```
     """
+
     def __init__(self, name: str, item_type: str, value: int) -> None:
         """Initializes an item.
 
@@ -45,6 +47,7 @@ class Item:
         self.item_type = item_type
         self.value = value
 
+
 class Inventory:
     """Represents an inventory for a character.
 
@@ -61,6 +64,7 @@ class Inventory:
         inventory.add_item(sword)
         ```
     """
+
     def __init__(self) -> None:
         """Initializes an empty inventory.
 

--- a/src/arbrynnica/modifier.py
+++ b/src/arbrynnica/modifier.py
@@ -10,6 +10,7 @@ Typical usage example:
     ```
 """
 
+
 class Modifier:
     """Represents a modifier in the RPG.
 
@@ -28,6 +29,7 @@ class Modifier:
         strength_modifier = Modifier("Strength", 2, "flat", "global")
         ```
     """
+
     def __init__(self, name: str, value: int, type: str, scope: str, duration: int = 0) -> None:
         """Initializes a modifier.
 
@@ -49,7 +51,7 @@ class Modifier:
         self.scope = scope
         self.duration = duration
 
-    def apply_effect(self, character: 'Character') -> None:
+    def apply_effect(self, character: "Character") -> None:
         """Applies the effect of the modifier to the character.
 
         Call this method to apply the modifier's effect to the character's attributes or abilities.
@@ -65,7 +67,7 @@ class Modifier:
         """
         pass  # Implementation for applying effect
 
-    def remove_effect(self, character: 'Character') -> None:
+    def remove_effect(self, character: "Character") -> None:
         """Removes the effect of the modifier from the character.
 
         Call this method to remove the modifier's effect from the character's attributes or abilities.
@@ -81,7 +83,7 @@ class Modifier:
         """
         pass  # Implementation for removing effect
 
-    def is_active(self, character: 'Character') -> bool:
+    def is_active(self, character: "Character") -> bool:
         """Checks if the modifier is active on the character.
 
         Call this method to check if the modifier is still active on the character.

--- a/src/arbrynnica/spell.py
+++ b/src/arbrynnica/spell.py
@@ -19,6 +19,7 @@ Typical usage example:
 
 from typing import Callable
 
+
 class Spell:
     """Represents a spell in the RPG.
 
@@ -39,6 +40,7 @@ class Spell:
         fireball = Spell("Fireball", 3, fireball_effect)
         ```
     """
+
     def __init__(self, name: str, level: int, effect: Callable) -> None:
         """Initializes a spell.
 
@@ -59,7 +61,7 @@ class Spell:
         self.level = level
         self.effect = effect
 
-    def cast(self, caster: 'Character', target: 'Character') -> None:
+    def cast(self, caster: "Character", target: "Character") -> None:
         """Casts the spell on a target character.
 
         Call this method to cast the spell from the caster to the target, applying the spell's effect.

--- a/src/arbrynnica/utils/dice_roller.py
+++ b/src/arbrynnica/utils/dice_roller.py
@@ -12,7 +12,7 @@ Typical usage example:
     result = DiceRoller.roll('3d6')
     print(result)
 
-    result = DiceRoller.roll('4d6', drop_lowest=True)
+    result = DiceRoller.roll(DiceRollConfig(4, 6, drop_lowest=True))
     print(result)
     ```
 """
@@ -20,7 +20,8 @@ Typical usage example:
 import random
 from typing import Optional, Union
 
-class _DiceRollConfig:
+
+class DiceRollConfig:
     """Configuration class for dice rolling.
 
     This class holds the configuration for a dice roll, including the number of dice, the number of sides on each die, and whether to drop the lowest roll.
@@ -32,11 +33,12 @@ class _DiceRollConfig:
 
     Example:
         ```python
-        config = _DiceRollConfig(3, 6, drop_lowest=True)
-        result = DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
+        config = DiceRollConfig(3, 6, drop_lowest=True)
+        result = DiceRoller.roll(config)
         print(result)  # Example output: 14 (actual result will vary)
         ```
     """
+
     def __init__(self, num_dice: int, num_sides: int, drop_lowest: bool = False) -> None:
         """Initializes the dice roll configuration.
 
@@ -47,14 +49,15 @@ class _DiceRollConfig:
 
         Example:
             ```python
-            config = _DiceRollConfig(3, 6, drop_lowest=True)
-            result = DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
+            config = DiceRollConfig(3, 6, drop_lowest=True)
+            result = DiceRoller.roll(config)
             print(result)  # Example output: 14 (actual result will vary)
             ```
         """
         self.num_dice = num_dice
         self.num_sides = num_sides
         self.drop_lowest = drop_lowest
+
 
 class DiceRoller:
     """Utility class for rolling dice.
@@ -69,11 +72,13 @@ class DiceRoller:
     """
 
     @staticmethod
-    def roll(num_dice: Union[int, str], num_sides: Optional[int] = None, drop_lowest: bool = False) -> int:
+    def roll(
+        num_dice: Union[int, str, DiceRollConfig], num_sides: Optional[int] = None, drop_lowest: bool = False
+    ) -> int:
         """Rolls a specified number of dice with a given number of sides.
 
         Args:
-            num_dice (Union[int, str]): Number of dice to roll or dice notation (e.g., '3d6').
+            num_dice (Union[int, str, DiceRollConfig]): Number of dice to roll, dice notation (e.g., '3d6'), or a DiceRollConfig object.
             num_sides (Optional[int]): Number of sides on each die. Required if num_dice is an int.
             drop_lowest (bool): Whether to drop the lowest roll. Defaults to False.
 
@@ -93,25 +98,32 @@ class DiceRoller:
             result = DiceRoller.roll('3d6')
             print(result)  # Example output: 12 (actual result will vary)
 
-            # Roll with the lowest die dropped
-            result = DiceRoller.roll('4d6', drop_lowest=True)
+            # Roll with the lowest die dropped using DiceRollConfig
+            config = DiceRollConfig(4, 6, drop_lowest=True)
+            result = DiceRoller.roll(config)
             print(result)  # Example output: 14 (actual result will vary)
             ```
         """
+        if isinstance(num_dice, DiceRollConfig):
+            return DiceRoller.roll(num_dice.num_dice, num_dice.num_sides, num_dice.drop_lowest)
+
         if isinstance(num_dice, str):
             config = DiceRoller._parse_dice_notation(num_dice, drop_lowest)
             return DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
 
-        if num_dice < 1 or num_sides is None or num_sides < 1:
-            raise ValueError("Number of dice and sides must be at least 1.")
+        if not isinstance(num_dice, int) or num_dice < 1:
+            raise ValueError(f"Invalid number of dice: {num_dice}. It must be a positive integer.")
+
+        if num_sides is None or not isinstance(num_sides, int) or num_sides < 1:
+            raise ValueError(f"Invalid number of sides: {num_sides}. It must be a positive integer.")
 
         rolls = [random.randint(1, num_sides) for _ in range(num_dice)]
-        if drop_lowest:
+        if drop_lowest and len(rolls) > 1:
             return sum(sorted(rolls)[1:])
         return sum(rolls)
 
     @staticmethod
-    def _parse_dice_notation(dice_notation: str, drop_lowest: bool = False) -> _DiceRollConfig:
+    def _parse_dice_notation(dice_notation: str, drop_lowest: bool = False) -> DiceRollConfig:
         """Parses a dice notation string and returns a configuration object.
 
         Args:
@@ -119,7 +131,7 @@ class DiceRoller:
             drop_lowest (bool): Whether to drop the lowest roll. Defaults to False.
 
         Returns:
-            _DiceRollConfig: Configuration object based on the provided notation.
+            DiceRollConfig: Configuration object based on the provided notation.
 
         Raises:
             ValueError: If the notation is not in the supported format.
@@ -127,13 +139,13 @@ class DiceRoller:
         Example:
             ```python
             config = DiceRoller._parse_dice_notation('3d6', drop_lowest=True)
-            result = DiceRoller.roll(config.num_dice, config.num_sides, config.drop_lowest)
+            result = DiceRoller.roll(config)
             print(result)  # Example output: 14 (actual result will vary)
             ```
         """
         try:
-            num_dice, num_sides = map(int, dice_notation.split('d'))
-        except ValueError:
-            raise ValueError("Unsupported dice notation format.")
+            num_dice, num_sides = map(int, dice_notation.split("d"))
+        except (ValueError, TypeError):
+            raise ValueError(f"Unsupported dice notation format: {dice_notation}. Expected format 'NdM'.")
 
-        return _DiceRollConfig(num_dice=num_dice, num_sides=num_sides, drop_lowest=drop_lowest)
+        return DiceRollConfig(num_dice=num_dice, num_sides=num_sides, drop_lowest=drop_lowest)

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -6,6 +6,7 @@ from arbrynnica.character import Character, CharacterClass, Abilities, Alignment
 from arbrynnica.modifier import Modifier
 from arbrynnica.condition import Condition
 
+
 def test_character_creation():
     """Test character creation with basic attributes."""
     char_class = CharacterClass("Fighter", 10, ["strength", "constitution"], [], [], [])
@@ -24,6 +25,7 @@ def test_character_creation():
     assert character.char_class.prime_requisites == ["strength", "constitution"]
     assert character.conditions == []
     assert character.modifiers == []
+
 
 def test_calculate_hit_points():
     """Test hit points calculation with and without modifiers."""
@@ -44,6 +46,7 @@ def test_calculate_hit_points():
     character.remove_modifier(hp_modifier)
     assert character.calculate_hit_points() == 12
 
+
 def test_gain_experience_and_level_up():
     """Test gaining experience and leveling up."""
     char_class = CharacterClass("Fighter", 10, ["strength", "constitution"], [], [], [])
@@ -58,8 +61,9 @@ def test_gain_experience_and_level_up():
 
     character.gain_experience(1000)
     character.check_level_up()  # Explicitly checking level up
-    assert character.experience_points == 2000 # TODO: Ensure this initiates level up
+    assert character.experience_points == 2000  # TODO: Ensure this initiates level up
     # assert character.level == 2  # TODO: Leveling not yet implemented
+
 
 def test_gain_experience_and_level_up_edge_cases():
     """Test gaining experience and edge cases for leveling up."""
@@ -73,8 +77,9 @@ def test_gain_experience_and_level_up_edge_cases():
     assert character.level == 1
 
     # Gain experience exactly at the threshold
-    character.gain_experience(1) # TODO: Ensure this initiates level up
+    character.gain_experience(1)  # TODO: Ensure this initiates level up
     # assert character.level == 2 # TODO: Leveling not yet implemented
+
 
 def test_apply_and_remove_conditions():
     """Test applying and removing conditions."""
@@ -91,6 +96,7 @@ def test_apply_and_remove_conditions():
     # Remove condition
     character.remove_condition(condition)
     assert condition not in character.conditions
+
 
 def test_apply_and_remove_conditions_edge_cases():
     """Test applying and removing conditions, including stacking and removal."""

--- a/tests/test_dice_roller.py
+++ b/tests/test_dice_roller.py
@@ -3,35 +3,40 @@
 import pytest
 from arbrynnica.utils.dice_roller import DiceRoller
 
+
 def test_roll():
     """Test rolling a specified number of dice with a given number of sides."""
     result = DiceRoller.roll(3, 6)
     assert 3 <= result <= 18
+
 
 def test_roll_with_drop_lowest():
     """Test rolling a specified number of dice with dropping the lowest roll."""
     result = DiceRoller.roll(4, 6, drop_lowest=True)
     assert 3 <= result <= 18
 
+
 def test_roll_with_notation():
     """Test rolling dice using notation."""
-    result = DiceRoller.roll('3d6')
+    result = DiceRoller.roll("3d6")
     assert 3 <= result <= 18
 
-    result_drop_lowest = DiceRoller.roll('4d6', drop_lowest=True)
+    result_drop_lowest = DiceRoller.roll("4d6", drop_lowest=True)
     assert 3 <= result_drop_lowest <= 18
+
 
 def test_parse_dice_notation():
     """Test parsing dice notation strings and rolling dice accordingly."""
-    config_3d6 = DiceRoller._parse_dice_notation('3d6')
+    config_3d6 = DiceRoller._parse_dice_notation("3d6")
     assert config_3d6.num_dice == 3
     assert config_3d6.num_sides == 6
     assert not config_3d6.drop_lowest
 
-    config_4d6_drop_lowest = DiceRoller._parse_dice_notation('4d6', drop_lowest=True)
+    config_4d6_drop_lowest = DiceRoller._parse_dice_notation("4d6", drop_lowest=True)
     assert config_4d6_drop_lowest.num_dice == 4
     assert config_4d6_drop_lowest.num_sides == 6
     assert config_4d6_drop_lowest.drop_lowest
+
 
 def test_roll_invalid_input():
     """Test rolling dice with invalid inputs."""
@@ -44,13 +49,14 @@ def test_roll_invalid_input():
     with pytest.raises(ValueError):
         DiceRoller.roll(3, -1)
 
+
 def test_parse_dice_notation_invalid_input():
     """Test parsing invalid dice notation strings."""
     with pytest.raises(ValueError):
-        DiceRoller._parse_dice_notation('2d')
+        DiceRoller._parse_dice_notation("2d")
     with pytest.raises(ValueError):
-        DiceRoller._parse_dice_notation('d6')
+        DiceRoller._parse_dice_notation("d6")
     with pytest.raises(ValueError):
-        DiceRoller._parse_dice_notation('3d6 drop')
+        DiceRoller._parse_dice_notation("3d6 drop")
     with pytest.raises(ValueError):
-        DiceRoller._parse_dice_notation('3d6 keep highest')
+        DiceRoller._parse_dice_notation("3d6 keep highest")


### PR DESCRIPTION
- `dice_roller.roll()` now supports `DiceRollConfig` as a param (which is once again public)
- All files: formatted with `ruff`

> [!NOTE]
> I forget what I asked of the panel on the `DiceRoller` changes. Just noticed the changes were sitting on disk this morning, and it's been long enough now that I don't remember how they came about. Oopsies! 😳 